### PR TITLE
Remove profile image and adjust About section styling

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -26,11 +26,7 @@ export default async function LocaleLayout({
   const en = locale === 'en';
   return (
     <html lang={locale}>
-      <body
-        className={`${
-          en ? montserrat.className : montserrat.className
-        }  selection:bg-[#FFF7C2]`}
-      >
+      <body className={`${en ? montserrat.className : montserrat.className}`}>
         <GradientDiv className='[#FFFDFD] min-h-screen  text-black'>
           <Header />
           {children}

--- a/app/[locale]/sections/About.tsx
+++ b/app/[locale]/sections/About.tsx
@@ -19,7 +19,7 @@ const About = () => {
           <div className='flex flex-col gap-6'>
             <div className='flex flex-col gap-8 lg:mr-auto lg:flex-row'>
               <div
-                className={`${roboto.className} mr-auto text-sm leading-relaxed lg:w-3/4`}
+                className={`${roboto.className} mr-auto text-sm leading-relaxed`}
               >
                 {t('desc')}
                 <span
@@ -39,13 +39,6 @@ const About = () => {
 
                 <p className='mt-4'>{t('desc5')}</p>
               </div>
-              <Image
-                src='/profile.jpg'
-                width={180}
-                height={180}
-                alt='profile image'
-                className='mx-auto items-center justify-center rounded-full lg:ml-auto'
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
This pull request makes minor adjustments to the layout and About section of the application. The main changes involve removing some styling and an image from the About section, as well as simplifying the body class in the layout.

Layout and Styling Updates:

* Removed the custom selection background color from the `<body>` element in `layout.tsx`, simplifying the class assignment. ([app/[locale]/layout.tsxL29-R29](diffhunk://#diff-44ca66e460fac15e804a2ab56f6038ef2dd0a231881294f0a3895f9ad7624c58L29-R29))
* Removed the `lg:w-3/4` class from the `About` section to adjust layout sizing. ([app/[locale]/sections/About.tsxL22-R22](diffhunk://#diff-eca92c0069725220811c3a9c243c3848af36d894735c867da083775c1ca003ffL22-R22))

About Section Content:

* Removed the profile image (`/profile.jpg`) from the About section, streamlining the content. ([app/[locale]/sections/About.tsxL42-L48](diffhunk://#diff-eca92c0069725220811c3a9c243c3848af36d894735c867da083775c1ca003ffL42-L48))

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::selection#accessibility
> Don't override selected text styles for purely aesthetic reasons — users can customize them to suit their needs. For people experiencing cognitive concerns or who are less technologically literate, unexpected changes to selection styles may hurt their understanding of the functionality.

I'm not sure why I set the style at that time  🤷‍♀️ 